### PR TITLE
Fix missing hash symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v1.0.1
+
+### Fixed
+
+- Fixed missing lead hash symbols for strings that begins with `HELP` and `TYPE` tokens in prometheus formatter
+
 ## v1.0.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Fixed
 
-- Fixed missing lead hash symbols for strings that begins with `HELP` and `TYPE` tokens in prometheus formatter
+- Fixed missing lead hash symbols for strings that begins with `HELP` and `TYPE` tokens in prometheus formatter [#4]
+
+[#4]: https://github.com/avto-dev/app-metrics-laravel/issues/4
 
 ## v1.0.0
 

--- a/src/Formatters/PrometheusFormatter.php
+++ b/src/Formatters/PrometheusFormatter.php
@@ -48,11 +48,11 @@ class PrometheusFormatter implements MetricFormatterInterface, UseCustomHttpHead
         foreach ($metrics as $metric) {
             if ($metric instanceof MetricInterface) {
                 if ($metric instanceof HasDescriptionInterface) {
-                    $result .= "HELP {$metric->name()} {$metric->description()}" . $this->new_line;
+                    $result .= "# HELP {$metric->name()} {$metric->description()}" . $this->new_line;
                 }
 
                 if ($metric instanceof HasTypeInterface) {
-                    $result .= "TYPE {$metric->name()} {$this->formatType($metric->type())}" . $this->new_line;
+                    $result .= "# TYPE {$metric->name()} {$this->formatType($metric->type())}" . $this->new_line;
                 }
 
                 $labels_string = $metric instanceof HasLabelsInterface

--- a/tests/Formatters/PrometheusFormatterTest.php
+++ b/tests/Formatters/PrometheusFormatterTest.php
@@ -108,7 +108,7 @@ class PrometheusFormatterTest extends AbstractUnitTestCase
         $result = $this->formatter->format([$mock]);
 
         $this->assertSame(
-            "HELP blah fake\nTYPE blah UNTYPED\nblah{foo=\"1\",bar=\"3.14\",baz=\"yahoo\"} 1",
+            "# HELP blah fake\n# TYPE blah UNTYPED\nblah{foo=\"1\",bar=\"3.14\",baz=\"yahoo\"} 1",
             $result
         );
     }
@@ -138,7 +138,7 @@ class PrometheusFormatterTest extends AbstractUnitTestCase
 
             $result = $this->formatter->format([$mock]);
 
-            $this->assertRegExp("~TYPE foo {$expected}\n~", $result);
+            $this->assertRegExp("~# TYPE foo {$expected}\n~", $result);
             $this->assertRegExp('~foo 1~', $result);
         }
     }
@@ -228,7 +228,7 @@ class PrometheusFormatterTest extends AbstractUnitTestCase
             $this->formatter->setLineBreaker($breaker);
             $result = $this->formatter->format([$mock]);
 
-            $this->assertRegExp("~TYPE foo UNTYPED{$breaker}~", $result);
+            $this->assertRegExp("~# TYPE foo UNTYPED{$breaker}~", $result);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No

## Description

### Fixed

- Fixed missing lead hash symbols for strings that begins with `HELP` and `TYPE` tokens in prometheus formatter

Fixes #4

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code
- [x] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/app-metrics-laravel/blob/master/CHANGELOG.md) file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
